### PR TITLE
Allow to set options as remove allows it.

### DIFF
--- a/src/vue-cookie.js
+++ b/src/vue-cookie.js
@@ -31,11 +31,11 @@ import {
 	remove(key, options = null) {
 	    removeCookie(key, options);
 	},
-	flush() {
+	flush(options = null) {
 	    const cookieKeys = Object.keys(this.getAll());
 	    const that = this;
 	    cookieKeys.forEach((element) => {
-		that.remove(element);
+		that.remove(element, options);
 	    });
 	},
     };


### PR DESCRIPTION
If the cookies are created with the `domain` option set, then `flush` would fail to remove all keys because it doesn't remove keys from the specific domain